### PR TITLE
feat: 약 조회 기능 추가, 로그인, 회원가입 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 
 	//쿼리 파라미터 로그 남기기
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+
+	//Google Vision API
+	implementation 'com.google.cloud:google-cloud-vision:3.34.0'
 }
 
 dependencyManagement {

--- a/src/main/java/com/_candoit/drfood/DrfoodApplication.java
+++ b/src/main/java/com/_candoit/drfood/DrfoodApplication.java
@@ -10,6 +10,7 @@ public class DrfoodApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(DrfoodApplication.class, args);
+		System.out.println("Google Credentials Path: " + System.getenv("GOOGLE_APPLICATION_CREDENTIALS"));
 	}
 
 }

--- a/src/main/java/com/_candoit/drfood/controller/GoogleVisionOCRController.java
+++ b/src/main/java/com/_candoit/drfood/controller/GoogleVisionOCRController.java
@@ -1,0 +1,29 @@
+package com._candoit.drfood.controller;
+
+import com._candoit.drfood.service.GoogleVisionOCR;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/api/ocr")
+@RequiredArgsConstructor
+public class GoogleVisionOCRController {
+
+    @Autowired
+    private GoogleVisionOCR googleVisionOCR;
+
+    @PostMapping("/parseImage")
+    public ResponseEntity<String> extractText(@RequestParam("imageUrl") String imageUrl) {
+        try {
+            String mostFrequentDisease = googleVisionOCR.execute(imageUrl);
+            return ResponseEntity.ok(mostFrequentDisease);
+        } catch (Exception e) {
+            //e.printStackTrace();
+            return ResponseEntity.status(500).body("Error: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/_candoit/drfood/controller/MemberController.java
+++ b/src/main/java/com/_candoit/drfood/controller/MemberController.java
@@ -1,0 +1,33 @@
+package com._candoit.drfood.controller;
+
+import com._candoit.drfood.domain.Member;
+import com._candoit.drfood.req.LoginRequest;
+import com._candoit.drfood.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/member")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/register")
+    public ResponseEntity<?> registerMember(@RequestBody Member member) {
+        memberService.calculateAndSaveMember(member);
+        return new ResponseEntity<>("Member successfully registered!", HttpStatus.CREATED);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> loginMember(@RequestBody LoginRequest loginRequest) {
+        try {
+            Member member = memberService.login(loginRequest.getId(), loginRequest.getPassword());
+            return new ResponseEntity<>(member, HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.UNAUTHORIZED);
+        }
+    }
+}

--- a/src/main/java/com/_candoit/drfood/domain/Drug.java
+++ b/src/main/java/com/_candoit/drfood/domain/Drug.java
@@ -1,0 +1,23 @@
+package com._candoit.drfood.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "drug")
+@Getter @Setter
+public class Drug {
+
+    @Id @GeneratedValue
+    @Column(name = "drug_code")
+    private Long drugCode;
+
+    private String drugName;
+
+    private String companyName;
+
+    private String drugCategory;
+
+    private String diseaseCategory;
+}

--- a/src/main/java/com/_candoit/drfood/domain/Member.java
+++ b/src/main/java/com/_candoit/drfood/domain/Member.java
@@ -2,6 +2,7 @@ package com._candoit.drfood.domain;
 
 import com._candoit.drfood.domain.enums.DietControl;
 import com._candoit.drfood.domain.enums.ExerciseStatus;
+import com._candoit.drfood.domain.enums.Gender;
 import com._candoit.drfood.domain.enums.UserDisease;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -17,7 +18,9 @@ public class Member {
 
     @Id @GeneratedValue
     @Column(name = "user_id")
-    private Long id;
+    private Long userId;
+
+    private String id;
 
     private String password;
 
@@ -27,6 +30,9 @@ public class Member {
     private UserDisease userDisease;
 
     private String phoneNum;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
 
     private String height;
 

--- a/src/main/java/com/_candoit/drfood/domain/enums/Gender.java
+++ b/src/main/java/com/_candoit/drfood/domain/enums/Gender.java
@@ -1,0 +1,5 @@
+package com._candoit.drfood.domain.enums;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/src/main/java/com/_candoit/drfood/repository/DrugRepository.java
+++ b/src/main/java/com/_candoit/drfood/repository/DrugRepository.java
@@ -1,0 +1,11 @@
+package com._candoit.drfood.repository;
+
+import com._candoit.drfood.domain.Drug;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DrugRepository extends JpaRepository<Drug, Long> {
+    // 약품명으로 질병 조회
+    Drug findByDrugName(String drugName);
+}

--- a/src/main/java/com/_candoit/drfood/repository/MemberRepository.java
+++ b/src/main/java/com/_candoit/drfood/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package com._candoit.drfood.repository;
+
+import com._candoit.drfood.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findById(String id);
+}

--- a/src/main/java/com/_candoit/drfood/req/LoginRequest.java
+++ b/src/main/java/com/_candoit/drfood/req/LoginRequest.java
@@ -1,0 +1,10 @@
+package com._candoit.drfood.req;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class LoginRequest {
+    private String id;
+    private String password;
+}

--- a/src/main/java/com/_candoit/drfood/service/DrugQueryService.java
+++ b/src/main/java/com/_candoit/drfood/service/DrugQueryService.java
@@ -1,0 +1,43 @@
+package com._candoit.drfood.service;
+
+import com._candoit.drfood.domain.Drug;
+import com._candoit.drfood.repository.DrugRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+public class DrugQueryService {
+
+    @Autowired
+    private DrugRepository drugRepository;
+
+    public String getDiseaseCategory(Set<String> drugNames) {
+        Map<String, Integer> diseaseCount = new HashMap<>();
+
+        for (String drugName : drugNames) {
+            Drug drug = drugRepository.findByDrugName(drugName);
+
+            if (drug != null) {
+                String diseaseCategory = drug.getDiseaseCategory();
+
+                // "고혈압, 당뇨"와 같이 여러 질병이 포함된 경우 분리하여 카운트
+                String[] diseases = diseaseCategory.split(",");
+                for (String disease : diseases) {
+                    disease = disease.trim(); // 공백 제거
+                    diseaseCount.put(disease, diseaseCount.getOrDefault(disease, 0) + 1);
+                }
+            }
+        }
+
+        // 가장 많이 사용된 질병 카테고리 return
+        return diseaseCount.entrySet()
+                .stream()
+                .max(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElse("Unknown Disease Category");
+    }
+}

--- a/src/main/java/com/_candoit/drfood/service/GoogleVisionOCR.java
+++ b/src/main/java/com/_candoit/drfood/service/GoogleVisionOCR.java
@@ -1,0 +1,84 @@
+package com._candoit.drfood.service;
+
+import com.google.cloud.vision.v1.*;
+import com.google.protobuf.ByteString;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StopWatch;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+public class GoogleVisionOCR {
+
+    @Autowired
+    private DrugQueryService drugQueryService;
+
+    public String execute(String imageUrl) throws IOException {
+        StopWatch totalTime = new StopWatch();
+        totalTime.start();
+
+        // 이미지 로드
+        URL url = new URL(imageUrl);
+        ByteString imgBytes;
+        try (InputStream in = url.openStream()) {
+            imgBytes = ByteString.readFrom(in);
+        }
+
+        // Vision API 요청 생성
+        Image img = Image.newBuilder().setContent(imgBytes).build();
+        Feature feat = Feature.newBuilder().setType(Feature.Type.TEXT_DETECTION).build();
+        AnnotateImageRequest request = AnnotateImageRequest.newBuilder()
+                .addFeatures(feat)
+                .setImage(img)
+                .build();
+        List<AnnotateImageRequest> requests = new ArrayList<>();
+        requests.add(request);
+
+        // 텍스트 및 위치 정보 저장
+        StringBuilder stringBuilder = new StringBuilder();
+
+        Set<String> uniqueLines = new HashSet<>();
+
+        try (ImageAnnotatorClient client = ImageAnnotatorClient.create()) {
+            BatchAnnotateImagesResponse response = client.batchAnnotateImages(requests);
+
+            for (AnnotateImageResponse res : response.getResponsesList()) {
+                if (res.hasError()) {
+                    System.out.printf("Error: %s\n", res.getError().getMessage());
+                    return "Error detected";
+                }
+
+                String fullText = res.getFullTextAnnotation().getText();
+                String[] lines = fullText.split("\n");
+
+                // 약품명 필터링 조건 적용
+                for (String line : lines) {
+                    // 약품명이 "정", "캡슐", "액", "주", "원", "환"으로 끝나는 경우
+                    if (line.matches(".*(정|캡슐|액|주|원|환)$")) {
+                        uniqueLines.add(line.trim()); // HashSet에 추가
+                    }
+                    // 위 내용으로 끝나지 않는 경우, 뒤에 숫자 또는 "("가 있는 경우
+                    else if (line.matches(".*(정|캡슐|액|주|원|환)(\\s*\\(|\\s*\\d+).*")) {
+                        uniqueLines.add(line.trim()); // HashSet에 추가
+                    }
+                }
+            }
+
+            System.out.println(uniqueLines);
+            // 약품명으로 가장 빈도 높은 질병 카테고리를 조회
+            String mostFrequentDisease = drugQueryService.getDiseaseCategory(uniqueLines);
+
+
+            totalTime.stop();
+            System.out.println("총 시간 : " + totalTime.getTotalTimeMillis() + "ms");
+            return mostFrequentDisease;
+        }
+    }
+}

--- a/src/main/java/com/_candoit/drfood/service/MemberService.java
+++ b/src/main/java/com/_candoit/drfood/service/MemberService.java
@@ -1,0 +1,56 @@
+package com._candoit.drfood.service;
+
+import com._candoit.drfood.domain.Member;
+import com._candoit.drfood.domain.enums.Gender;
+import com._candoit.drfood.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public void calculateAndSaveMember(Member member) {
+        double standardWeight;
+
+        if (member.getGender().equals(Gender.MALE)) {
+            standardWeight = Math.pow(Double.parseDouble(member.getHeight()) / 100.0, 2) * 22;
+        } else {
+            standardWeight = Math.pow(Double.parseDouble(member.getHeight()) / 100.0, 2) * 21;
+        }
+
+        double dailyEnergy;
+        switch (member.getExerciseStatus()) {
+            case NONE :
+                dailyEnergy = standardWeight * 27;
+                break;
+            case REGULAR :
+                dailyEnergy = standardWeight * 32;
+                break;
+            case FREQUENT :
+                dailyEnergy = standardWeight * 37;
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid exercise status");
+        }
+
+        member.setDailyEnergy(BigDecimal.valueOf(dailyEnergy));
+        memberRepository.save(member);
+    }
+
+    public Member login(String id, String password) {
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        if (!member.getPassword().equals(password)) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        return member;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://34.47.89.53:3306/dr.food?useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC&createDatabaseIfNotExist=true
+    url: jdbc:mysql://34.64.173.186:3306/dr_food?useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC&createDatabaseIfNotExist=true
 
   jpa:
     hibernate:


### PR DESCRIPTION
1. OCR 인식 시 약 이름 추출해 DB 조회 후 해당하는 질병 반환
API 호출(POST) : http://localhost:8080/api/ocr/parsImage
Query Params 
1. imageUrl(이미지 주소) 필요

2. 회원가입 기능 추가
API 호출(POST) : http://localhost:8080/api/member/register
회원가입 시 요청 본문 필요
Body JSON Example:
{
    "id": "testuser",
    "password": "password123",
    "name": "서석현",
    "userDisease": "DIABETES",
    "phoneNum": "01074217751",
    "gender": "MALE",
    "height": "175",
    "weight": "70",
    "exerciseStatus": "REGULAR",
    "address": "서울시 은평구 연서로 487",
    "dietControl": "NORMAL"
}

3. 로그인 기능 추가
API 호출(POST) : http://localhost:8080/api/member/login
로그인시 요청 본문 필요
Body JSON Example:
{
    "id": "testuser",
    "password": "pasword123"
}