### PR TITLE
fix: Member 컬럼명 변경 및 Login 기능 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/src/main/java/com/_candoit/drfood/controller/DrugController.java
+++ b/src/main/java/com/_candoit/drfood/controller/DrugController.java
@@ -1,0 +1,34 @@
+package com._candoit.drfood.controller;
+
+import com._candoit.drfood.service.DrugQueryService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.multipart.MultipartFile;
+
+@Controller
+public class DrugController {
+
+//    @Autowired
+//    private DrugQueryService drugQueryService;
+//
+//    // 파일 업로드 페이지
+//    @GetMapping("/upload")
+//    public String upload() {
+//        return "upload";
+//    }
+//
+//    // csv 파일 업로드 처리
+//    @PostMapping("/upload")
+//    public String uploadFile(MultipartFile file, Model model) {
+//        try {
+//            String result = drugQueryService.saveDrugsFromCsv(file);
+//            model.addAttribute("message", result);
+//        } catch (Exception e) {
+//            model.addAttribute("error", "파일 업로드 중 오류 발생: " + e.getMessage());
+//        }
+//        return "upload";
+//    }
+}

--- a/src/main/java/com/_candoit/drfood/controller/MemberController.java
+++ b/src/main/java/com/_candoit/drfood/controller/MemberController.java
@@ -24,7 +24,7 @@ public class MemberController {
     @PostMapping("/login")
     public ResponseEntity<?> loginMember(@RequestBody LoginRequest loginRequest) {
         try {
-            Member member = memberService.login(loginRequest.getId(), loginRequest.getPassword());
+            Member member = memberService.login(loginRequest.getLoginId(), loginRequest.getPassword());
             return new ResponseEntity<>(member, HttpStatus.OK);
         } catch (IllegalArgumentException e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.UNAUTHORIZED);

--- a/src/main/java/com/_candoit/drfood/domain/Member.java
+++ b/src/main/java/com/_candoit/drfood/domain/Member.java
@@ -19,10 +19,11 @@ public class Member {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "userId")
+    @Column(name = "user_id")
     private Long userId;
 
-    private String id;
+    @Column(name = "login_id")
+    private String loginId;
 
     private String password;
 

--- a/src/main/java/com/_candoit/drfood/repository/MemberRepository.java
+++ b/src/main/java/com/_candoit/drfood/repository/MemberRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findById(String id);
+    Optional<Member> findByLoginId(String id);
 }

--- a/src/main/java/com/_candoit/drfood/req/LoginRequest.java
+++ b/src/main/java/com/_candoit/drfood/req/LoginRequest.java
@@ -5,6 +5,6 @@ import lombok.Setter;
 
 @Getter @Setter
 public class LoginRequest {
-    private String id;
+    private String loginId;
     private String password;
 }

--- a/src/main/java/com/_candoit/drfood/service/DrugQueryService.java
+++ b/src/main/java/com/_candoit/drfood/service/DrugQueryService.java
@@ -4,8 +4,12 @@ import com._candoit.drfood.domain.Drug;
 import com._candoit.drfood.repository.DrugRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -40,4 +44,13 @@ public class DrugQueryService {
                 .map(Map.Entry::getKey)
                 .orElse("Unknown Disease Category");
     }
+
+//    public String saveDrugsFromCsv(MultipartFile file) throws Exception{
+//        if (file.isEmpty()) {
+//            throw new Exception("파일이 비어있습니다.");
+//        }
+//
+//        Reader reader = new InputStreamReader(file.getInputStream());
+//        Iterator<CSVRecord> records = CSVFOR
+//    }
 }

--- a/src/main/java/com/_candoit/drfood/service/MemberService.java
+++ b/src/main/java/com/_candoit/drfood/service/MemberService.java
@@ -43,8 +43,8 @@ public class MemberService {
         memberRepository.save(member);
     }
 
-    public Member login(String id, String password) {
-        Member member = memberRepository.findById(id)
+    public Member login(String loginId, String password) {
+        Member member = memberRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
 
         if (!member.getPassword().equals(password)) {


### PR DESCRIPTION
1. Member 엔티티 id -> loginId로 변경
기본키인 userId의 db 컬럼명을 user_id(스네이크 표기법)으로 변경

2. Login 기능 수정