### PR TITLE
feat: 사용자 질병 저장 기능 구현

### DIFF
--- a/src/main/java/com/_candoit/drfood/controller/MemberController.java
+++ b/src/main/java/com/_candoit/drfood/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com._candoit.drfood.controller;
 
 import com._candoit.drfood.domain.Member;
+import com._candoit.drfood.domain.enums.UserDisease;
 import com._candoit.drfood.req.LoginRequest;
 import com._candoit.drfood.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +39,16 @@ public class MemberController {
             return new ResponseEntity<>(member, HttpStatus.OK);
         } catch (IllegalArgumentException e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.UNAUTHORIZED);
+        }
+    }
+
+    @PostMapping("/saveDisease")
+    public ResponseEntity<?> saveDisease(@RequestParam Long userId, @RequestParam UserDisease disease) {
+        try {
+            memberService.updateDisease(userId, disease);
+            return new ResponseEntity<>("저장되었습니다!", HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
         }
     }
 

--- a/src/main/java/com/_candoit/drfood/service/MemberService.java
+++ b/src/main/java/com/_candoit/drfood/service/MemberService.java
@@ -2,10 +2,12 @@ package com._candoit.drfood.service;
 
 import com._candoit.drfood.domain.Member;
 import com._candoit.drfood.domain.enums.Gender;
+import com._candoit.drfood.domain.enums.UserDisease;
 import com._candoit.drfood.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 
@@ -63,5 +65,13 @@ public class MemberService {
         }
 
         return member;
+    }
+
+    @Transactional
+    public void updateDisease(Long userId, UserDisease disease) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+        member.setUserDisease(disease);
+        memberRepository.save(member);
     }
 }


### PR DESCRIPTION
1. 약 봉투 OCR 인식 후 사용자에게 질병이 맞는지 확인 후 저장하는 방식으로 변경
2. API 호출(Post) : http://localhost:8080/api/member/saveDisease
Query Param : userId, disease 필요
예시 : http://localhost:8080/api/member/saveDisease?userId=1&disease=HYPERTENSION
성공 시(200) : 저장되었습니다.
실패 시 (400) : BAD_REQUEST 